### PR TITLE
fix(toolbar): remove z-index on toolbar

### DIFF
--- a/src/jinn-tap.css
+++ b/src/jinn-tap.css
@@ -21,7 +21,6 @@ jinn-tap > nav {
     grid-area: toolbar;
     position: sticky;
     top: 0;
-    z-index: 100;
     background-color: var(--jinn-tap-background-color, white);
 }
 


### PR DESCRIPTION
it causes nasty overlapping issues, and the toolbar is overlapping the content anyway