### PR TITLE
fix(jinn-toast): do not register jinn-toast if its already there

### DIFF
--- a/src/components/jinn-toast.js
+++ b/src/components/jinn-toast.js
@@ -168,4 +168,6 @@ export class JinnToast extends HTMLElement {
     }
 }
 
-customElements.define('jinn-toast', JinnToast);
+if (!customElements.get('jinn-toast')) {
+    customElements.define('jinn-toast', JinnToast);
+}


### PR DESCRIPTION
Fore also includes jinn-toast. Making it register twice. While Fore does include this check, jinn-tap does not.

Why is this not an NPM dep on https://github.com/jinnelements/jinn-toast?