### PR TITLE
Feat/prevent text input

### DIFF
--- a/cypress/e2e/jinn-tap.cy.js
+++ b/cypress/e2e/jinn-tap.cy.js
@@ -221,8 +221,9 @@ describe('JinnTap Component', () => {
             // Set the content
             $component[0].content = testContent;
         });
-
-        cy.get('jinn-tap').invoke('attr', 'block-typing', 'true');
+        cy.get('jinn-tap').then(($component) => {
+            $component[0].editor.commands.togglePreventTyping();
+        });
 
         // Typing, backspace, CUT should all be blocked now
         cy.get('jinn-tap[block-typing]')
@@ -271,8 +272,9 @@ describe('JinnTap Component', () => {
 
             expect(editor.xml).to.equal(wrapInTEIBoilerplate('Initial Content'));
         });
-
-        cy.get('jinn-tap').invoke('attr', 'block-typing', null);
+        cy.get('jinn-tap').then(($component) => {
+            $component[0].editor.commands.togglePreventTyping();
+        });
         cy.get('jinn-tap').then(($component) => {
             $component[0].editor.commands.setTextSelection({ from: 1, to: 1 });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@semantic-release/github": "^9.2.6",
         "@semantic-release/npm": "^10.0.4",
         "chai-xml": "^0.4.1",
-        "cypress": "^14.2.1",
+        "cypress": "^15.9.0",
         "jsonwebtoken": "^9.0.2",
         "prettier": "^3.6.2",
         "semantic-release": "^22.0.8",
@@ -75,7 +75,6 @@
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
       "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -86,7 +85,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -96,7 +94,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
       "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -109,7 +106,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
       "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -122,7 +118,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
       "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -136,7 +131,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
       "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -154,7 +148,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
       "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -170,7 +163,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
       "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
@@ -181,7 +173,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
       "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/lang-html": "^6.0.0",
@@ -197,7 +188,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
       "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.4.0",
@@ -212,7 +202,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
       "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -227,7 +216,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
       "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0"
       }
@@ -237,7 +225,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.4.tgz",
       "integrity": "sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -249,7 +236,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
       "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.37.0",
@@ -261,7 +247,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -271,7 +256,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
       "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -284,7 +268,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.14.tgz",
       "integrity": "sha512-WJcvgHm/6Q7dvGT0YFv/6PSkoc36QlR0VCESS6x9tGsnF1lWLmmYxOgX3HH6v8fo6AvSLgpcs+H0Olre6MKXlg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -308,7 +291,6 @@
       "resolved": "https://registry.npmjs.org/@cwmr/paper-autocomplete/-/paper-autocomplete-4.0.0.tgz",
       "integrity": "sha512-ZBTglN2qGFS/d5Cd76R0k1SadXgWXDsoOgFRoYyLwvb98rZFPlS8dnsLIpWjFWBinz4nEqZ2pE/HOLTvE2heNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0",
         "@polymer/iron-icon": "^3.0.0",
@@ -869,7 +851,6 @@
       "resolved": "https://registry.npmjs.org/@jinntec/jinn-codemirror/-/jinn-codemirror-1.18.2.tgz",
       "integrity": "sha512-DxO9Psqg/cIQ/bOPySFeTw/N+ITMZc8e8HvS5oREvfIAK9glndwXq/MuL+4J4d12vfdty1VD2OL0TPAv5OeXKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.1",
         "@codemirror/autocomplete": "^6.18.0",
@@ -890,15 +871,13 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lezer/css": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
       "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -910,7 +889,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -920,7 +898,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
       "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -932,7 +909,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
       "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
@@ -944,7 +920,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
       "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -956,7 +931,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
       "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -966,7 +940,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
       "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0"
@@ -977,7 +950,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
       "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -994,15 +966,13 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@lrnwebcomponents/es-global-bridge/-/es-global-bridge-7.0.4.tgz",
       "integrity": "sha512-31028XpXiRm0qQKu2EbAhPxFXhbybown4LSna4S+mb45oXTuZgtV4kEf9PPu9kYzzZBxyT60HOofUwUXk/RK8A==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1058,6 +1028,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1238,7 +1209,6 @@
       "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-1.1.0.tgz",
       "integrity": "sha512-mYwHCfr736cIWWdhhSZvDbf90AKt2xyrJspKFC3qyIJG1LtrJeJunYEqCGG4Aq2ijENbc4WkOjszcvNaIAS/pQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@orchidjs/unicode-variants": "^1.1.2"
       }
@@ -1247,8 +1217,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.1.2.tgz",
       "integrity": "sha512-5DobW1CHgnBROOEpFlEXytED5OosEWESFvg/VYmH0143oXcijYTprRYJTs+55HzGM4IqxiLFSuqEzu9mPNwVsA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -1300,7 +1269,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/app-layout/-/app-layout-3.1.0.tgz",
       "integrity": "sha512-+jf5/TtUDj/la9Vi59ooGNjnTN8JTkyIUK8gxAms0N3MmyeqrmcNLlJKDVyE6IIGKz0WfFeGKqKtmtTLHrZIlg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/iron-media-query": "^3.0.0-pre.26",
@@ -1313,15 +1281,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
       "integrity": "sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@polymer/iron-a11y-announcer": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-announcer/-/iron-a11y-announcer-3.2.0.tgz",
       "integrity": "sha512-We+hyaFHcg7Ke8ovsoxUpYEXFIJLHxMCDaLehTB4dELS+C+K0zMnGSiqQvb/YzGS+nSYpAfkQIyg1msOCdHMtA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1331,7 +1297,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz",
       "integrity": "sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1341,7 +1306,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-ajax/-/iron-ajax-3.0.1.tgz",
       "integrity": "sha512-7+TPEAfWsRdhj1Y8UeF1759ktpVu+c3sG16rJiUC3wF9+woQ9xI1zUm2d59i7Yc3aDEJrR/Q8Y262KlOvyGVNg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1351,7 +1315,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-autogrow-textarea/-/iron-autogrow-textarea-3.0.3.tgz",
       "integrity": "sha512-5r0VkWrIlm0JIp5E5wlnvkw7slK72lFRZXncmrsLZF+6n1dg2rI8jt7xpFzSmUWrqpcyXwyKaGaDvUjl3j4JLA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -1364,7 +1327,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-behaviors/-/iron-behaviors-3.0.1.tgz",
       "integrity": "sha512-IMEwcv1lhf1HSQxuyWOUIL0lOBwmeaoSTpgCJeP9IBYnuB1SPQngmfRuHKgK6/m9LQ9F9miC7p3HeQQUdKAE0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1375,7 +1337,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-checked-element-behavior/-/iron-checked-element-behavior-3.0.1.tgz",
       "integrity": "sha512-aDr0cbCNVq49q+pOqa6CZutFh+wWpwPMLpEth9swx+GkAj+gCURhuQkaUYhIo5f2egDbEioR1aeHMnPlU9dQZA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
         "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
@@ -1387,7 +1348,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-dropdown/-/iron-dropdown-3.0.1.tgz",
       "integrity": "sha512-22yLhepfcKjuQMfFmRHi/9MPKTqkzgRrmWWW0P5uqK++xle53k2QBO5VYUAYiCN3ZcxIi9lEhZ9YWGeQj2JBig==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
@@ -1400,7 +1360,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-fit-behavior/-/iron-fit-behavior-3.1.0.tgz",
       "integrity": "sha512-ABcgIYqrjhmUT8tiuolqeGttF/8pd3sEymUDrO1vXbZu4FWIvoLNndrMDFvs++AGd12Mjf5pYy84NJc6dB8Vig==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1410,7 +1369,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
       "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1420,7 +1378,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-form/-/iron-form-3.0.1.tgz",
       "integrity": "sha512-JwSQXHjYALsytCeBkXlY8aRwqgZuYIqzOk3iHuugb1RXOdZ7MZHyJhMDVBbscHjxqPKu/KaVzAjrcfwNNafzEA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-ajax": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1431,7 +1388,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-form-element-behavior/-/iron-form-element-behavior-3.0.1.tgz",
       "integrity": "sha512-G/e2KXyL5AY7mMjmomHkGpgS0uAf4ovNpKhkuUTRnMuMJuf589bKqE85KN4ovE1Tzhv2hJoh/igyD6ekHiYU1A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1441,7 +1397,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
       "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/iron-meta": "^3.0.0-pre.26",
@@ -1453,7 +1408,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-icons/-/iron-icons-3.0.1.tgz",
       "integrity": "sha512-xtEI8erH2GIBiF3QxEMyW81XuVjguu6Le5WjEEpX67qd9z7jjmc4T/ke3zRUlnDydex9p8ytcwVpMIKcyvjYAQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-icon": "^3.0.0-pre.26",
         "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
@@ -1465,7 +1419,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-iconset/-/iron-iconset-3.0.1.tgz",
       "integrity": "sha512-9ByfHE8qWTYibmX/RwUvsZrVhnEdbdQMh/It6OSlfbjV/RRqWA42Qaut5F+mdA5MmBUjCdTsggubehcbDOdwhA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-meta": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1476,7 +1429,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
       "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-meta": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1487,7 +1439,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-image/-/iron-image-3.0.2.tgz",
       "integrity": "sha512-VyYtnewGozDb5sUeoLR1OvKzlt5WAL6b8Od7fPpio5oYL+9t061/nTV8+ZMrpMgF2WgB0zqM/3K53o3pbK5v8Q==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1497,7 +1448,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-input/-/iron-input-3.0.1.tgz",
       "integrity": "sha512-WLx13kEcbH9GKbj9+pWR6pbJkA5kxn3796ynx6eQd2rueMyUfVTR3GzOvadBKsciUuIuzrxpBWZ2+3UcueVUQQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
         "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
@@ -1509,7 +1459,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-label/-/iron-label-3.0.1.tgz",
       "integrity": "sha512-MkIZ1WfOy10pnIxRwTVPfsoDZYlqMkUp0hmimMj0pGRHmrc9n5phuJUY1pC+S7WoKP1/98iH2qnXQukPGTzoVA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1519,7 +1468,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-media-query/-/iron-media-query-3.0.1.tgz",
       "integrity": "sha512-czUX1pm1zfmfcZtq5J57XFkcobBv08Y50exp0/3v8Bos5VL/jv2tU0RwiTfDBxUMhjicGbgwEBFQPY2V5DMzyw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1529,7 +1477,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-menu-behavior/-/iron-menu-behavior-3.0.2.tgz",
       "integrity": "sha512-8dpASkFNBIkxAJWsFLWIO1M7tKM0+wKs3PqdeF/dDdBciwoaaFgC2K1XCZFZnbe2t9/nJgemXxVugGZAWpYCGg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -1542,7 +1489,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
       "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1552,7 +1498,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-overlay-behavior/-/iron-overlay-behavior-3.0.3.tgz",
       "integrity": "sha512-Q/Fp0+uOQQ145ebZ7T8Cxl4m1tUKYjyymkjcL2rXUm+aDQGb1wA1M1LYxUF5YBqd+9lipE0PTIiYwA2ZL/sznA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
@@ -1565,7 +1510,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-pages/-/iron-pages-3.0.1.tgz",
       "integrity": "sha512-PQe8S1JKHPcsIvFOaQP+9+AXmqUIL9fPqC6xT63OAZQxYCeZJDKgT9GKBx+VRryYBUlj2FLEXkUVpG+PTotdjg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
         "@polymer/iron-selector": "^3.0.0-pre.26",
@@ -1577,7 +1521,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-range-behavior/-/iron-range-behavior-3.0.1.tgz",
       "integrity": "sha512-+jtL9v45M/T1RJleWyQaNH84S9/mIIR+AjNbYIttbKGp1eG+98j8MDWe7LXNtg79V2LQnE/+VS82cBeELyGVeg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1587,7 +1530,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
       "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1597,7 +1539,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-scroll-target-behavior/-/iron-scroll-target-behavior-3.0.1.tgz",
       "integrity": "sha512-xg1WanG25BIkQE8rhuReqY9zx1K5M7F+YAIYpswEp5eyDIaZ1Y3vUmVeQ3KG+hiSugzI1M752azXN7kvyhOBcQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1607,7 +1548,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-selector/-/iron-selector-3.0.1.tgz",
       "integrity": "sha512-sBVk2uas6prW0glUe2xEJJYlvxmYzM40Au9OKbfDK2Qekou/fLKcBRyIYI39kuI8zWRaip8f3CI8qXcUHnKb1A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1617,7 +1557,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-validatable-behavior/-/iron-validatable-behavior-3.0.1.tgz",
       "integrity": "sha512-wwpYh6wOa4fNI+jH5EYKC7TVPYQ2OfgQqocWat7GsNWcsblKYhLYbwsvEY5nO0n2xKqNfZzDLrUom5INJN7msQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-meta": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1628,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/neon-animation/-/neon-animation-3.0.1.tgz",
       "integrity": "sha512-cDDc0llpVCe0ATbDS3clDthI54Bc8YwZIeTGGmBJleKOvbRTUC5+ssJmRL+VwVh+VM5FlnQlx760ppftY3uprg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
         "@polymer/iron-selector": "^3.0.0-pre.26",
@@ -1640,7 +1578,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-behaviors/-/paper-behaviors-3.0.1.tgz",
       "integrity": "sha512-6knhj69fPJejv8qR0kCSUY+Q0XjaUf0OSnkjRjmTJPAwSrRYtgqE+l6P1FfA+py1X/cUjgne9EF5rMZAKJIg1g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
@@ -1653,7 +1590,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-button/-/paper-button-3.0.1.tgz",
       "integrity": "sha512-JRNBc+Oj9EWnmyLr7FcCr8T1KAnEHPh6mosln9BUdkM+qYaYsudSICh3cjTIbnj6AuF5OJidoLkM1dlyj0j6Zg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/paper-behaviors": "^3.0.0-pre.27",
@@ -1666,7 +1602,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-card/-/paper-card-3.0.1.tgz",
       "integrity": "sha512-ZYzfA4kzP9niRO22wSOBL2RS+URZNUP5XmUCwN91fYPIGO0Qbimh7d1O2HpJD4cRCZhvGYn2CJMDMVmDm35vIg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/iron-image": "^3.0.0-pre.26",
@@ -1679,7 +1614,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-checkbox/-/paper-checkbox-3.1.0.tgz",
       "integrity": "sha512-kXm6yDG1tT8if0XuJ2cc9NF+g8Ev4wG+rnf0a+Sx+O7J6fn1jcnBlYn72FlrfjVjDQZDBFmT6nynhD5PvFw8iQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
@@ -1694,7 +1628,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-dialog/-/paper-dialog-3.0.1.tgz",
       "integrity": "sha512-KvglYbEq7AWJvui2j6WKLnOvgVMeGjovAydGrPRj7kVzCiD49Eq/hpYFJTRV5iDcalWH+mORUpw+jrFnG9+Kgw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
         "@polymer/neon-animation": "^3.0.0-pre.26",
@@ -1707,7 +1640,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-behavior/-/paper-dialog-behavior-3.0.1.tgz",
       "integrity": "sha512-wbI4kCK8le/9MHT+IXzvHjoatxf3kd3Yn0tgozAiAwfSZ7N4Ubpi5MHrK0m9S9PeIxKokAgBYdTUrezSE5378A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
         "@polymer/paper-styles": "^3.0.0-pre.26",
@@ -1719,7 +1651,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-scrollable/-/paper-dialog-scrollable-3.0.1.tgz",
       "integrity": "sha512-1E8B9kNdL58jUrJ/BwqJeOoNVcxNrB559z//d1V0rVHWT5bWCCZegwS3G06iFK5MjxWFbIKzleVTLrT0opiZkA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
@@ -1732,7 +1663,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-dropdown-menu/-/paper-dropdown-menu-3.2.0.tgz",
       "integrity": "sha512-2ohwSHF+RLSK6kA0UkkMiMQF6EZcaEYWAA25kfisI6DWie7yozKrpQNsqvwfOEHU6DdDMIotrOtH1TM88YS8Zg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
@@ -1752,7 +1682,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-fab/-/paper-fab-3.0.1.tgz",
       "integrity": "sha512-LO8ckgd72MnAtC1WiPd5CFR27WC/dEuY/lOIQuHYdEjwI62+iiV7Bmr7uoQ9wvvV71qMFdMIOyq/03KklsuAzw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/iron-icon": "^3.0.0-pre.26",
@@ -1766,7 +1695,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-icon-button/-/paper-icon-button-3.0.2.tgz",
       "integrity": "sha512-kOdxQgnKL097bggFF6PWvsBYuWg+MCcoHoTHX6bh/MuZoWFZNjrFntFqwuB4oEbpjCpfm4moA33muPJFj7CihQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-icon": "^3.0.0-pre.26",
         "@polymer/paper-behaviors": "^3.0.0-pre.27",
@@ -1779,7 +1707,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-input/-/paper-input-3.2.1.tgz",
       "integrity": "sha512-6ghgwQKM6mS0hAQxQqj+tkeEY1VUBqAsrasAm8V5RpNcfSWQC/hhRFxU0beGuKTAhndzezDzWYP6Zz4b8fExGg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-autogrow-textarea": "^3.0.0-pre.26",
@@ -1795,7 +1722,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-item/-/paper-item-3.0.1.tgz",
       "integrity": "sha512-KTk2N+GsYiI/HuubL3sxebZ6tteQbBOAp4QVLAnbjSPmwl+mJSDWk+omuadesU0bpkCwaWVs3fHuQsmXxy4pkw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -1808,7 +1734,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-listbox/-/paper-listbox-3.0.1.tgz",
       "integrity": "sha512-vMLWFpYcggAPmEDBmK+96fFefacOG3GLB1EguTn8+ZkqI+328hNfw1MzHjH68rgCIIUtjmm+9qgB1Sy/MN0a/A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
@@ -1821,7 +1746,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-material/-/paper-material-3.0.1.tgz",
       "integrity": "sha512-FUa3iqEcwjYtUzMqIh9cEfdTJE8ZtRasAzxVbck5GChthA/T2HwnhjAyqzN4lusVMyafdl3rjNEwhVPK/Pmykg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/paper-styles": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1832,7 +1756,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-menu-button/-/paper-menu-button-3.1.0.tgz",
       "integrity": "sha512-q0G0/rvYD/FFmIBMGCQWjfXzRqwFw9+WHSYV4uOQzM1Ln8LMXSAd+2CENsbVwtMh6fmBePj15ZlU8SM2dt1WDQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
@@ -1848,7 +1771,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-progress/-/paper-progress-3.0.1.tgz",
       "integrity": "sha512-5nguG+tmnyoaWKVNG8Smtno2uLSPBgEsT3f20JY8yJTjUBYWaqa8E3l5RLkTRXgA4x9OnvLb8/CdlQWXQIogBg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
         "@polymer/iron-range-behavior": "^3.0.0-pre.26",
@@ -1861,7 +1783,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.2.tgz",
       "integrity": "sha512-DnLNvYIMsiayeICroYxx6Q6Hg1cUU8HN2sbutXazlemAlGqdq80qz3TIaVdbpbt/pvjcFGX2HtntMlPstCge8Q==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1872,7 +1793,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-styles/-/paper-styles-3.0.1.tgz",
       "integrity": "sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/font-roboto": "^3.0.1",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -1884,7 +1804,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-tabs/-/paper-tabs-3.1.0.tgz",
       "integrity": "sha512-t8G+3CiyI0R+wA077UNQXR/oG9GlsqRRO1KMsFHHjBSsYqWXghNsqxUG827wEj+PafI5u9tZ3vVt1S++Lg4B2g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-behaviors": "^3.0.0-pre.26",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -1903,7 +1822,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/paper-tooltip/-/paper-tooltip-3.0.1.tgz",
       "integrity": "sha512-yiUk09opTEnE1lK+tb501ENb+yQBi4p++Ep0eGJAHesVYKVMPNgPphVKkIizkDaU+n0SE+zXfTsRbYyOMDYXSg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@polymer/paper-styles": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1914,7 +1832,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
       "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -1924,7 +1841,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2813,6 +2729,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.19.0.tgz",
       "integrity": "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3075,6 +2992,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.19.0.tgz",
       "integrity": "sha512-N6nKbFB2VwMsPlCw67RlAtYSK48TAsAUgjnD+vd3ieSlIufdQnLXDFUP6hFKx9mwoUVUgZGz02RA6bkxOdYyTw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3193,6 +3111,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.19.0.tgz",
       "integrity": "sha512-ZmGUhLbMWaGqnJh2Bry+6V4M6gMpUDYo4D1xNux5Gng/E/eYtc+PMxMZ/6F7tNTAuujLBOQKj6D+4SsSm457jw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3207,6 +3126,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.19.0.tgz",
       "integrity": "sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3349,6 +3269,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3365,7 +3292,6 @@
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.4.tgz",
       "integrity": "sha512-QZwPSc5yhaOQKGT4oKABmgQDjCGwa24HK9tP7E/TauMse8/kIDyAHaocdeUamk6+93fa/Wj6rtAHeakSSGU7AQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@uiw/codemirror-themes": "4.25.4"
       },
@@ -3378,7 +3304,6 @@
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.25.4.tgz",
       "integrity": "sha512-9sWHf18fB7Fe6QuBbxGeZiKar9fG/v+6+wKWf7ATZUMkaNRSALURQxIccNn6KfWIVRblUJgoOPzmoFidVRn53Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@uiw/codemirror-themes": "4.25.4"
       },
@@ -3391,7 +3316,6 @@
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.4.tgz",
       "integrity": "sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -3411,7 +3335,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.4.0.tgz",
       "integrity": "sha512-C94F07OOb5Ciq2BY4CklIQG+WJFA6QoTFDQl8JJloJgPI12b9kmyP8uRgfq4VAHHusqKqIvA8AB6VZuGg5lagg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.2.1",
@@ -3426,7 +3349,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.6.tgz",
       "integrity": "sha512-3edQSooBoHVC3RexL6hi3/26HMGvG1jlxLq6ffH9c+GapuZ9zh6E2KyZa/Sz1jmLZwfZII7exgwkHhEYUZZrJA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -3435,15 +3357,13 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
       "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@vaadin/vaadin-element-mixin": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-2.4.2.tgz",
       "integrity": "sha512-VSDVK0XUsFe/RohpwSzQwgqb2Pwpok6sDNhIDS4CARr3HPhq2voMzT/FowFbkEy0J1hFtN/ZfC7tkv3kdEKKIQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
@@ -3455,7 +3375,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-item/-/vaadin-item-2.3.0.tgz",
       "integrity": "sha512-hG1MQ8cLaFlsoqSZFm8bqXrHxMry6vtkJrpiXArxpaZXMwPkJnfrUT3D6Qm/NG/rZHvOzZa5U/1k5+dyledlHA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
@@ -3469,7 +3388,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.5.3.tgz",
       "integrity": "sha512-IMbtb2i8IJTE9+Krm33QdtV+SgouJnnf3VAdZGenIPiKef1kypeYBeECVG63PftTTApI8pR8U0zr1kWFi+H/tw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1"
@@ -3480,7 +3398,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
       "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-icon": "^3.0.0",
         "@polymer/iron-iconset-svg": "^3.0.0",
@@ -3492,7 +3409,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-1.3.2.tgz",
       "integrity": "sha512-EFrvGScoxhLNrPnWtT2Ia77whjF2TD4jrcyeh1jv9joCA2n5SUba+4XJciVSGmopqqQato6lwRnZSvMLJX7cyw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -3502,7 +3418,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-progress-bar/-/vaadin-progress-bar-1.3.0.tgz",
       "integrity": "sha512-kPkG2M99UHHJVMX8TNN++KdU/rLTsDuDTNLUypcNVWDGDo0oHOY2P29yqwu8x6rGM3bIzgyQIgNSukKmIAjYcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
@@ -3516,7 +3431,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-tabs/-/vaadin-tabs-3.2.0.tgz",
       "integrity": "sha512-Uwn6/Ys8lmc+ChVBRF8VhLWOoSu9JQ2yVFlvOiWygAgTEhTAWcKe9CkiE7SivFGJ43bNr/aW9pf35ft0jjDU5A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
@@ -3533,7 +3447,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.2.tgz",
       "integrity": "sha512-PZZOZnke3KUlZsDrRVbWxAGEeFBPRyRayNRCvip0XnQK+Zs3cLuRgdgbdro3Ir9LZ3Izsw6HqA6XNMKffEP67A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "lit-element": "^2.0.0"
@@ -3544,7 +3457,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-upload/-/vaadin-upload-4.4.4.tgz",
       "integrity": "sha512-H2gnvaNeGSW/y4mCo5+bqQ3w9hf6HGGLJe7mdgg07CWQjco5ArZj21vaVwHbKJiyk+cRYGh2fbBQEctILdRovQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-button": "^2.4.0",
@@ -3561,7 +3473,6 @@
       "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       },
@@ -3573,22 +3484,19 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
       "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@webcomponents/webcomponentsjs": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.8.0.tgz",
       "integrity": "sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -3600,8 +3508,7 @@
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
       "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -3632,7 +3539,6 @@
       "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.12.2.tgz",
       "integrity": "sha512-HS3VytUBTKj8A0vPl7DDr5p/w3IOGv6RXL0fv7eczOWAtj9Xe8ri4TAiZRXoOyo+Z/COADCj+oARFenbxhmkIg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=8.0.0 <15",
         "abort-controller": "^3.0.0",
@@ -3648,15 +3554,13 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/animejs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/animejs/-/animejs-3.2.2.tgz",
       "integrity": "sha512-Ao95qWLpDPXXM+WrmwcKbl6uNlC5tjnowlaRYtuVDHHoygjtIPfDUoK9NthrlZsQSKjZXlmji2TrBUAVbiH0LQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -3801,13 +3705,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/async-lock": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
@@ -3925,8 +3822,7 @@
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.34.1.tgz",
       "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -4108,16 +4004,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/check-more-types": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -4148,8 +4034,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
       "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -4217,7 +4102,6 @@
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
       "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -4332,8 +4216,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
       "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -4404,8 +4287,7 @@
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4529,7 +4411,6 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
       "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
@@ -4539,24 +4420,24 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.5.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.4.tgz",
-      "integrity": "sha512-0Dhm4qc9VatOcI1GiFGVt8osgpPdqJLHzRwcAB5MSD/CAAts3oybvPUPawHyvJZUd8osADqZe/xzMsZ8sDTjXw==",
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.9.0.tgz",
+      "integrity": "sha512-Ks6Bdilz3TtkLZtTQyqYaqtL/WT3X3APKaSLhTV96TmTyudzSjc6EJsJCHmBb7DxO+3R12q3Jkbjgm/iPgmwfg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.9",
+        "@cypress/request": "^3.0.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
+        "@types/tmp": "^0.2.3",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
         "ci-info": "^4.1.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "0.6.1",
@@ -4571,10 +4452,8 @@
         "extract-zip": "2.0.1",
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
         "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
@@ -4584,9 +4463,9 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "systeminformation": "^5.27.14",
+        "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
@@ -4595,7 +4474,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/cypress/node_modules/execa": {
@@ -4669,7 +4548,6 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -4845,6 +4723,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -5088,7 +4967,6 @@
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -5104,7 +4982,6 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -5116,7 +4993,6 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -5189,7 +5065,6 @@
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -5219,7 +5094,6 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -5230,7 +5104,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5284,7 +5157,6 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -5600,16 +5472,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.0"
-      }
-    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -5733,7 +5595,6 @@
       "resolved": "https://registry.npmjs.org/gridjs/-/gridjs-5.1.0.tgz",
       "integrity": "sha512-ElT4RccHVZXR6mAn0Neh7jRv0yLPYLl9tWr9EC1tIJ7UC035kScGc/VMSJlPmOTyUU6qPUz1mtmzg/i8+IT24g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "preact": "^10.10.6"
       }
@@ -5860,7 +5721,6 @@
       "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.13.15.tgz",
       "integrity": "sha512-gHh8a/cPTCpanraePpjRxyIlxDFrIhYqjuh01UHWEwDpglJKCnvLW8kqSx5gQtOuSsJogNZXLhOdbSExpgUiqg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
@@ -5923,7 +5783,6 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.8.1.tgz",
       "integrity": "sha512-uDOyiSExuqIOoF1G5hzgyaPkds5RgOlLmklw/wR7vlsbmQ8lBuzjoV2qiL2H0jMp+xkdrHHjt0w00H0fuHpVWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1"
       }
@@ -5933,7 +5792,6 @@
       "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz",
       "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.19.0"
       }
@@ -5943,7 +5801,6 @@
       "resolved": "https://registry.npmjs.org/i18next-chained-backend/-/i18next-chained-backend-2.1.0.tgz",
       "integrity": "sha512-Cr9+kA0mIGZJHLliSdRfoAlrRbKrqWV2+73NXoq6dToC6RhoAJS3fR0E/UdXFMpQJuNdVr2i8VeO6pt6kqyQAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
@@ -5954,7 +5811,6 @@
       "integrity": "sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==",
       "deprecated": "replaced by i18next-http-backend",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5"
       }
@@ -6294,8 +6150,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6467,16 +6322,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
@@ -6489,7 +6334,6 @@
       "resolved": "https://registry.npmjs.org/leaflet-control-geocoder/-/leaflet-control-geocoder-2.4.0.tgz",
       "integrity": "sha512-b2QlxuFd40uIDbnoUI3U9fzfnB4yKUYlmsXjquJ2d2YjoJqnyVYcIJeErAVv3kPvX3nI0gzvBq1XHMgSVFrGkQ==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "optionalDependencies": {
         "open-location-code": "^1.0.0"
       },
@@ -6502,7 +6346,6 @@
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
       "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "leaflet": "^1.3.1"
       }
@@ -6586,7 +6429,6 @@
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
       "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "lit-html": "^1.1.1"
       }
@@ -6595,8 +6437,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
       "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -6918,8 +6759,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0",
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -7074,8 +6914,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -7098,7 +6937,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10485,15 +10323,13 @@
       "resolved": "https://registry.npmjs.org/open-location-code/-/open-location-code-1.0.3.tgz",
       "integrity": "sha512-DBm14BSn40Ee241n80zIFXIT6+y8Tb0I+jTdosLJ8Sidvr2qONvymwqymVbHV2nS+1gkDZ5eTNpnOIVV0Kn2fw==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/openseadragon": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-5.0.1.tgz",
       "integrity": "sha512-a/hjouW9i3UfWxRADVYN2MyRhXMGnE7x9VVL7/4jXCcDLFyO4UM5o4RStYtqa5BfaHw/wMNAaD2WbxQF8f1pJg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/openseadragon"
       }
@@ -10630,7 +10466,6 @@
       "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.3.tgz",
       "integrity": "sha512-YtAN9JAjsQw1142gxEjEAwXvOF5nYQuDwnQ67RW2HZDkMLI+b4RsBE37lULZa9gAr6kDAOGBOhXI4wGMoY3raw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/polyfill": "^7.10.1",
         "@babel/runtime": "^7.21.0",
@@ -10709,8 +10544,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10814,7 +10648,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
       "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10863,7 +10696,6 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10997,6 +10829,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11026,6 +10859,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11086,6 +10920,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11344,8 +11179,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
@@ -14248,6 +14082,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15104,8 +14939,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -15151,6 +14985,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.30.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.7.tgz",
+      "integrity": "sha512-33B/cftpaWdpvH+Ho9U1b08ss8GQuLxrWHelbJT1yw4M48Taj8W3ezcPuaLoIHZz5V6tVHuQPr5BprEfnBLBMw==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/temp-dir": {
@@ -15255,7 +15116,6 @@
       "integrity": "sha512-9CWqBfYSPUaRFh9bE7yCYQ2GUHh6Cjln12RJO0VMhxIYAOJXVK7dKH+lJeJ4IkkWg7J2/PaVwHeoUbGZzkh4IQ==",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
-      "peer": true,
       "engines": {
         "node": ">= 16",
         "npm": ">= 8"
@@ -15266,7 +15126,6 @@
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
@@ -15319,7 +15178,6 @@
       "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.5.1.tgz",
       "integrity": "sha512-63D5/Qf6bb6kLSgksEuas/60oawDcuUHrD90jZofeOpF6bkQFYriKrvtpJBQQ4xIA5dUGcjhBbk/yrlfOQsy3g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@orchidjs/sifter": "^1.1.0",
         "@orchidjs/unicode-variants": "^1.1.2"
@@ -15349,8 +15207,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/traverse": {
       "version": "0.6.8",
@@ -15406,8 +15263,7 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
@@ -15474,8 +15330,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/uniqolor/-/uniqolor-1.1.1.tgz",
       "integrity": "sha512-HUwezlXCwm5bzsEXW7AP7ybezH13uWENRgYT+3dOdhJPvpYucSqvIGckMiLn+Uy2j0NVf3fPp43uZ4aun3t4Ww==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "3.0.0",
@@ -15579,7 +15434,6 @@
       "resolved": "https://registry.npmjs.org/verovio/-/verovio-3.16.0.tgz",
       "integrity": "sha512-+fJaQVwHOWzq9q1H7VJWbhxTkQ4bijnBz7gvKFbJGx2DcpTsr1A0hUpZXelqc6+n+DC/rC8V1eaUPJKuOBdVyQ==",
       "license": "LGPL-3.0-or-later",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       }
@@ -15676,15 +15530,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.2.tgz",
       "integrity": "sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/web-midi-player": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/web-midi-player/-/web-midi-player-1.4.1.tgz",
       "integrity": "sha512-bPK19kcDfMqzS/i8+1RRNDgd2KKuX6HO0bBwfZveQHsalS1S3K+sAAdiA7Pmnxp7J70IQwTDb4OSeN3z2uvnpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.14.1",
         "npm": "~6.2.0"
@@ -15694,15 +15546,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@semantic-release/github": "^9.2.6",
     "@semantic-release/npm": "^10.0.4",
     "chai-xml": "^0.4.1",
-    "cypress": "^14.2.1",
+    "cypress": "^15.9.0",
     "jsonwebtoken": "^9.0.2",
     "prettier": "^3.6.2",
     "semantic-release": "^22.0.8",

--- a/src/extensions/commands.js
+++ b/src/extensions/commands.js
@@ -5,7 +5,20 @@ export const JinnTapCommands = Extension.create({
     name: 'jinnTapCommands',
 
     addCommands() {
-        return {
+        /**
+         *
+         * @type {import('@tiptap/core').AnyCommands}
+         */
+        const commands = {
+            togglePreventTyping:
+                () =>
+                ({ view, dispatch }) => {
+                    if (dispatch) {
+                        view.dom.closest('jinn-tap').toggleAttribute('block-typing');
+                    }
+
+                    return view.dom.closest('jinn-tap').hasAttribute('block-typing');
+                },
             moveUp:
                 () =>
                 ({ commands, state }) => {
@@ -73,5 +86,7 @@ export const JinnTapCommands = Extension.create({
                     return true;
                 },
         };
+
+        return commands;
     },
 });

--- a/src/schema.json
+++ b/src/schema.json
@@ -121,7 +121,14 @@
                 },
                 "Cmd-i": {
                     "attributes": { "rend": "i" }
+                },
+				"ctrl-b": {
+                    "attributes": { "rend": "b" }
+                },
+                "ctrl-i": {
+                    "attributes": { "rend": "i" }
                 }
+
             },
             "toolbar": {
                 "Bold": {


### PR DESCRIPTION
In a project we want to use Jinntap to basically replace the annotation editor. The ability to quickly make changes is very powerful, and this way we only have one tool that does it all.

But there's one minus, it might be a bit too easy to make textual changes even though you really would not intend it. Making unexpected changes to the document. Therefore, a command to disable the editor! This:

- disables typing
- disables delete / backspace (removing content is the same as typing)
- disables cut and paste (which can also remove or insert content)

This also upgrades Cypress because newer Cypress introduces more Keys, for shortcuts.