### PR TITLE
Conditional node types

### DIFF
--- a/jats-editor-styles.css
+++ b/jats-editor-styles.css
@@ -190,18 +190,33 @@ jats-fn:not([_reference]) {
 }
 
 jats-xref {
-    font-size: 0.75rem;
-    vertical-align: super;
-    cursor: pointer;
-    line-height: 1;
+    font-style: italic;
     text-decoration: none;
 }
 
-jats-xref::before {
+jats-xref[ref-type="bibr"] {
+    color: #004499;
+}
+jats-xref[ref-type="bibr"]::after {
+    content: attr(ref-type);
+    font-size: 0.75rem;
+    vertical-align: super;
+    line-height: 1;
+}
+
+jats-xref[ref-type="fn"] {
+    font-size: 0.75rem;
+    font-style: normal;
+    vertical-align: super;
+    cursor: pointer;
+    line-height: 1;
+}
+
+jats-xref[ref-type="fn"]::before {
     content: attr(_reference);
 }
 
-jats-xref::after {
+jats-xref[ref-type="fn"]::after {
     content: '\200B';
 }
 

--- a/public/musk-trump-tei-publisher.xml
+++ b/public/musk-trump-tei-publisher.xml
@@ -72,18 +72,18 @@
         </article-meta>
     </front>
     <body>
-        <sec xml:id="introduction">
+        <sec id="introduction">
             <title>Introduction</title>
-            <p xml:id="p1">In an exclusive conversation, <named-content content-type="person"
+            <p id="p1">In an exclusive conversation, <named-content content-type="person"
                     specific-use="gnd-1062481119">Elon Musk</named-content> and <named-content
                     content-type="person" specific-use="gnd-118834312">Donald Trump</named-content>
                 discuss <ext-link>TEI Publisher</ext-link>, the revolutionary framework that's
-                transforming digital scholarly publishing<xref xml:id="xref-id1" ref-type="fn"
+                transforming digital scholarly publishing<xref id="xref-id1" ref-type="fn"
                     rid="fn1" type="note"/>. What follows is a transcript of their discussion about
                 this powerful, open-source platform.</p>
-            <sec xml:id="modular-architecture">
+            <sec id="modular-architecture">
                 <title>Modular Architecture: Building Blocks for Success</title>
-                <p xml:id="p2"><bold>Elon Musk:</bold> Look, the fundamental architecture of TEI
+                <p id="p2"><bold>Elon Musk:</bold> Look, the fundamental architecture of TEI
                     Publisher is brilliant. It's based on modular profiles - think of them as
                         <named-content content-type="term" specific-use="gnd-4140276-5"
                         >LEGO</named-content> blocks. You have base profiles, feature profiles,
@@ -94,7 +94,7 @@
                         content-type="organization" specific-use="gnd-1127363964"
                         >SpaceX</named-content>. You don't build the whole rocket at once; you build
                     modules, test them independently, then integrate.</p>
-                <p xml:id="p3"><bold>Donald Trump:</bold> Elon, you're absolutely right, and I know
+                <p id="p3"><bold>Donald Trump:</bold> Elon, you're absolutely right, and I know
                     about building things - I've built the greatest buildings, tremendous buildings.
                     And TEI Publisher? It's the same thing. You're building something great, but
                     you're doing it smart. You're not starting from scratch every time - that's
@@ -104,13 +104,13 @@
                     components, putting them together to make something tremendous. It's like
                         <named-content content-type="term" specific-use="gnd-4140276-5"
                         >LEGO</named-content>, but for computers. Very smart.</p>
-                <p xml:id="p4"><bold>Elon Musk:</bold> Exactly. And the Jinks application manager
+                <p id="p4"><bold>Elon Musk:</bold> Exactly. And the <xref ref-type="bibr" rid="ref2">Jinks</xref> application manager
                     takes this to another level. It's not a one-time generative step anymore. You
                     can iteratively add features, remove them, reconfigure. The system manages
                     updates automatically. This is critical for long-term sustainability - which is
                     something I think about constantly. We need systems that last, that can evolve,
                     that don't become obsolete. TEI Publisher is built for the long term.</p>
-                <p xml:id="p5"><bold>Donald Trump:</bold> Sustainability - that's important, very
+                <p id="p5"><bold>Donald Trump:</bold> Sustainability - that's important, very
                     important. And TEI Publisher is sustainable, believe me. It's open source, which
                     is tremendous. Open source means... well, it means it's open, right? Like,
                     anyone can see it. It's not locked up, it's not proprietary - I know
@@ -126,15 +126,15 @@
                     </caption>
                 </fig>
             </sec>
-            <sec xml:id="open-standards">
+            <sec id="open-standards">
                 <title>Open Standards: The Foundation of Interoperability</title>
-                <p xml:id="p6"><bold>Elon Musk:</bold> One of the most important aspects is that TEI
+                <p id="p6"><bold>Elon Musk:</bold> One of the most important aspects is that TEI
                     Publisher is built on open standards. It supports TEI XML, obviously, but also
                     DocBook, JATS, and even DOCX. It interfaces with IIIF for images, DTS for text
                     services, Open API Specification. This isn't proprietary nonsense - it's based
                     on well-documented, widely-used standards. That's crucial for interoperability
                     and future-proofing your data.</p>
-                <p xml:id="p7"><bold>Donald Trump:</bold> Standards - I love standards, especially
+                <p id="p7"><bold>Donald Trump:</bold> Standards - I love standards, especially
                     when they're the best standards. And these are the best standards. TEI, JATS,
                     DocBook - these are like the gold standard, the platinum standard. I know
                     standards, I've set standards in real estate, tremendous standards. These aren't
@@ -145,16 +145,16 @@
                     you're using these standards. That means your data works everywhere, it's
                     compatible with everything, like USB - you know USB, right? It's like that, but
                     for books and documents. That's tremendous value, tremendous value.</p>
-                <p xml:id="p8"><bold>Elon Musk:</bold> The framework follows the principle of
+                <p id="p8"><bold>Elon Musk:</bold> The framework follows the principle of
                     "standardize where you can, customize where you must." This is exactly right.
                     You don't force a one-size-fits-all solution, but you also don't reinvent
                     everything from scratch. Every element is customizable, but you start from a
                     solid, standards-based foundation. This is how you scale - you have common
                     infrastructure, but you allow for specialization.</p>
             </sec>
-            <sec xml:id="ease-of-use">
+            <sec id="ease-of-use">
                 <title>Ease of Use: Scholars Don't Need to Become Programmers</title>
-                <p xml:id="p9"><bold>Donald Trump:</bold> Now, here's what I really like - and I've
+                <p id="p9"><bold>Donald Trump:</bold> Now, here's what I really like - and I've
                     talked to many people about this, smart people, very smart people - TEI
                     Publisher lets scholars publish their work without becoming programmers. They
                     don't need to learn Python - I know Python, it's a snake, right? Or JavaScript -
@@ -163,14 +163,14 @@
                     editing. The technical stuff? TEI Publisher handles that. It's like having a
                     computer person, but it's not a person, it's the software. It's beautiful,
                     absolutely beautiful.</p>
-                <p xml:id="p10"><bold>Elon Musk:</bold> That's the key value proposition. The
+                <p id="p10"><bold>Elon Musk:</bold> That's the key value proposition. The
                     framework provides a smooth entry path for editors with limited technical
                     experience, while remaining endlessly flexible for advanced users. The Jinks
                     interface makes it simple - you select features, configure them through a
                     human-readable JSON file, and generate your application. But if you need to go
                     deeper, the entire system is extensible. You can create custom profiles, modify
                     existing ones, integrate with other systems.</p>
-                <p xml:id="p11"><bold>Donald Trump:</bold> And the configuration file - it's JSON,
+                <p id="p11"><bold>Donald Trump:</bold> And the configuration file - it's JSON,
                     which is simple, very simple. JSON - I think that stands for something, maybe
                     "Just Simple Options Now" or something like that. You don't need to be a
                     computer scientist to understand it - I'm not a computer scientist, and I
@@ -180,15 +180,15 @@
                     want control. TEI Publisher gives you that control, tremendous control. It's
                     like having the remote control, but for your website.</p>
             </sec>
-            <sec xml:id="versatility">
+            <sec id="versatility">
                 <title>Versatility: From Simple to Complex</title>
-                <p xml:id="p12"><bold>Elon Musk:</bold> What's remarkable is the range of projects
+                <p id="p12"><bold>Elon Musk:</bold> What's remarkable is the range of projects
                     TEI Publisher can handle. According to the documentation, it's been used for
                     scholarly editions, journals, monographs, lexicons, correspondence collections,
                     Buddhist inscriptions, poetry anthologies - the list goes on. This isn't a
                     specialized tool for one use case. It's a universal framework that adapts to
                     your needs.</p>
-                <p xml:id="p13"><bold>Donald Trump:</bold> Versatility - that's what makes it great,
+                <p id="p13"><bold>Donald Trump:</bold> Versatility - that's what makes it great,
                     the greatest. You can use it for anything. Letters? Yes. Books? Yes.
                     Dictionaries? Yes. Everything. And it works for simple projects and complex
                     projects - very complex projects. Some of these scholarly editions are
@@ -196,21 +196,21 @@
                     facsimiles - I think that's like copies or pictures - and multiple versions, all
                     that stuff. TEI Publisher handles it all. It's like a Swiss Army knife, but for
                     publishing. It's tremendous.</p>
-                <p xml:id="p14"><bold>Elon Musk:</bold> The framework can even generate camera-ready
+                <p id="p14"><bold>Elon Musk:</bold> The framework can even generate camera-ready
                     material for print publishing. So you're not locked into digital-only. You can
                     publish online, generate PDFs, create print volumes - all from the same source
                     data. This is efficiency. One source of truth, multiple output formats. That's
                     how you should build systems.</p>
             </sec>
-            <sec xml:id="data-organization">
+            <sec id="data-organization">
                 <title>Data Organization: Separation of Concerns</title>
-                <p xml:id="p15"><bold>Elon Musk:</bold> I really appreciate how TEI Publisher
+                <p id="p15"><bold>Elon Musk:</bold> I really appreciate how TEI Publisher
                     separates data from application code. You have a data collection that's
                     independent of the application. This means you can update your application
                     without touching your data, and vice versa. You can maintain separate
                     repositories, differentiate access privileges. This is proper software
                     architecture - separation of concerns.</p>
-                <p xml:id="p16"><bold>Donald Trump:</bold> Separation - that's smart, very smart.
+                <p id="p16"><bold>Donald Trump:</bold> Separation - that's smart, very smart.
                     Your data is your data, your application is your application. They work
                     together, but they're separate - like a prenuptial agreement, but for computers.
                     That means if you need to update something, you're not breaking everything. You
@@ -218,29 +218,29 @@
                     and keep your data safe. You can update your data, keep the application running.
                     It's flexible, tremendously flexible. It's like having separate bank accounts -
                     you know what I mean.</p>
-                <p xml:id="p17"><bold>Elon Musk:</bold> The system supports hierarchical collections
+                <p id="p17"><bold>Elon Musk:</bold> The system supports hierarchical collections
                     too. You can organize your data however makes sense for your project. You can
                     have subcollections for different types of material, and the framework handles
                     navigation automatically. If you include a collection.html file, it uses that
                     for the landing page. Otherwise, it generates a paginated list automatically.
                     This is intelligent default behavior with the ability to customize.</p>
             </sec>
-            <sec xml:id="community">
+            <sec id="community">
                 <title>Community-Driven Development</title>
-                <p xml:id="p18"><bold>Donald Trump:</bold> The community aspect - this is huge,
+                <p id="p18"><bold>Donald Trump:</bold> The community aspect - this is huge,
                     absolutely huge. TEI Publisher is community-driven. That means the features come
                     from real needs, from real users, from real projects. It's not some company
                     deciding what you need - I hate when big tech companies do that, very unfair -
                     it's the community, the users, the scholars, the editors. They say "we need
                     this," and the community builds it. It's like crowdsourcing, but for software.
                     That's how it should work. Very democratic.</p>
-                <p xml:id="p19"><bold>Elon Musk:</bold> The documentation explicitly states that
+                <p id="p19"><bold>Elon Musk:</bold> The documentation explicitly states that
                     features are "a response to real needs of user community: developed to provide a
                     generalized solution to a repeated practical requirement." This is the right
                     approach. You solve real problems, then generalize the solution so others can
                     benefit. This is how open source should work - solve problems once, share the
                     solution.</p>
-                <p xml:id="p20"><bold>Donald Trump:</bold> And because it's open source - I think
+                <p id="p20"><bold>Donald Trump:</bold> And because it's open source - I think
                     that means the code is open, like open for business - everything benefits the
                     community. When someone improves TEI Publisher - maybe they add a feature or fix
                     a bug, I think that's what they call problems in software - everyone benefits.
@@ -249,14 +249,14 @@
                     proprietary. It's open, it's free, it's tremendous. That's winning for everyone.
                     It's like a potluck dinner, but for software.</p>
             </sec>
-            <sec xml:id="future-proofing">
+            <sec id="future-proofing">
                 <title>Future-Proofing: Built to Last</title>
-                <p xml:id="p21"><bold>Elon Musk:</bold> Long-term preservation is critical. The
+                <p id="p21"><bold>Elon Musk:</bold> Long-term preservation is critical. The
                     framework is designed with sustainability in mind. It's based on XML, which is a
                     stable, well-understood format. It uses open standards that aren't going
                     anywhere. The modular architecture means you can update components
                     independently. This is how you build systems that last decades, not years.</p>
-                <p xml:id="p22"><bold>Donald Trump:</bold> Future-proof - that's what TEI Publisher
+                <p id="p22"><bold>Donald Trump:</bold> Future-proof - that's what TEI Publisher
                     is. It's not going to become obsolete next year, or in five years, or in ten
                     years. It's built on standards that have been around for decades - XML, I think
                     that's been around for a while, right? - standards that will be around for
@@ -264,15 +264,15 @@
                     It's not like buying a computer that becomes outdated in two years - I hate
                     that, very wasteful. This is built to last. That's peace of mind, tremendous
                     peace of mind.</p>
-                <p xml:id="p23"><bold>Elon Musk:</bold> The continuous development model through
+                <p id="p23"><bold>Elon Musk:</bold> The continuous development model through
                     Jinks means the framework evolves. As new profiles are added or updated, your
                     application can benefit automatically. The system manages dependencies, handles
                     updates, minimizes manual intervention. This is modern software development
                     applied to scholarly publishing.</p>
             </sec>
-            <sec xml:id="conclusion">
+            <sec id="conclusion">
                 <title>Conclusion: Why TEI Publisher Matters</title>
-                <p xml:id="p24"><bold>Donald Trump:</bold> So here's the bottom line - TEI Publisher
+                <p id="p24"><bold>Donald Trump:</bold> So here's the bottom line - TEI Publisher
                     is tremendous. It's open source - which I think means free, right? - it's
                     community-driven, it's based on the best standards - the gold standards,
                     platinum standards - it's easy to use, it's versatile, it's sustainable. It's
@@ -281,30 +281,30 @@
                     than whatever else is out there. Believe me, if you're doing digital publishing
                     - or is it electronic publishing? I think they're the same thing - you need TEI
                     Publisher. You just need it. It's a no-brainer.</p>
-                <p xml:id="p25"><bold>Elon Musk:</bold> I agree completely. TEI Publisher represents
+                <p id="p25"><bold>Elon Musk:</bold> I agree completely. TEI Publisher represents
                     the right way to build publishing infrastructure. It's modular, scalable,
                     standards-based, and community-driven. It solves real problems while remaining
                     flexible enough to adapt to new requirements. For anyone working in digital
                     humanities or scholarly publishing, this is the framework to use. It's not just
                     good - it's the right architectural approach.</p>
-                <p xml:id="p26"><bold>Donald Trump:</bold> And the best part? It's free. Open
+                <p id="p26"><bold>Donald Trump:</bold> And the best part? It's free. Open
                     source, completely free. You're not paying licensing fees - I know licensing
                     fees, I've paid licensing fees, tremendous fees - you're not locked into some
                     vendor, you're not dependent on some company. You're in control. It's like
                     owning your building instead of renting - you own it, you control it. That's
                     winning. That's how you win. Very smart.</p>
-                <p xml:id="p27"><bold>Elon Musk:</bold> The open source model ensures that
+                <p id="p27"><bold>Elon Musk:</bold> The open source model ensures that
                     improvements benefit everyone. As the community grows and contributes, the
                     entire ecosystem improves. This is how we accelerate progress - by building on
                     each other's work rather than reinventing wheels. TEI Publisher is a perfect
                     example of this principle in action.</p>
-                <p xml:id="p28"><bold>Donald Trump:</bold> So there you have it. Two of the smartest
+                <p id="p28"><bold>Donald Trump:</bold> So there you have it. Two of the smartest
                     people in the world - and I include myself in that, obviously - we both agree:
                     TEI Publisher is tremendous, it's the future, and you should be using it. It's
                     that simple. Very simple. Even I can understand it, and I'm not a computer
                     person - I'm a business person, a deal person. But this makes sense. It's like a
                     good deal, but for software. Very good deal.</p>
-                <p xml:id="p29"><bold>Elon Musk:</bold> The framework enables scholars to focus on
+                <p id="p29"><bold>Elon Musk:</bold> The framework enables scholars to focus on
                     scholarship while providing the technical infrastructure they need. It's
                     sustainable, extensible, and built on solid foundations. For digital scholarly
                     publishing, TEI Publisher is the obvious choice.</p>
@@ -344,9 +344,9 @@
             </ref>
         </ref-list>
         <fn-group>
-            <fn xml:id="fn1">
+            <fn id="fn1">
                 <p>This conversation was transcribed from a recorded discussion. Both participants
-                    were provided with TEI Publisher documentation prior to the discussion (one, of
+                    were provided with <xref ref-type="bibr" rid="ref1">TEI Publisher documentation</xref> prior to the discussion (one, of
                     course, never read his copy — he prefers to learn by osmosis, or so he
                     claims.)</p>
             </fn>

--- a/src/attribute-panel.js
+++ b/src/attribute-panel.js
@@ -304,7 +304,16 @@ export class AttributePanel {
             return;
         }
 
-        const def = this.schemaDef.schema[nodeOrMark.type.name];
+        let def = this.schemaDef.schema[nodeOrMark.type.name];
+        if (Array.isArray(def)) {
+            def = def[0];
+        } else if (!def) {
+            const m = nodeOrMark.type.name.match(/^(.+?)(\d+)$/);
+            if (m) {
+                const base = this.schemaDef.schema[m[1]];
+                if (Array.isArray(base)) def = base[parseInt(m[2])];
+            }
+        }
 
         if (!def) {
             this.panel.innerHTML = '';

--- a/src/extensions/extensions.js
+++ b/src/extensions/extensions.js
@@ -23,120 +23,167 @@ import { JinnReference } from './ref.js';
 export function createFromSchema(schemaDef, prefix = 'tei-', notesWrapper = 'listAnnotation', footnoteOptions = {}) {
     const JinnDocument = createDocumentExtension(notesWrapper);
     const extensions = [JinnDocument, Text];
-    Object.entries(schemaDef.schema).forEach(([name, def]) => {
-        let NodeOrMark;
-        switch (def.type) {
-            case 'inline':
-                NodeOrMark = JinnInline.extend({
-                    name: name,
-                });
-                break;
-            case 'anchor':
-                NodeOrMark = JinnAnchor.extend({
-                    name: name,
-                });
-                break;
-            case 'ref':
-                NodeOrMark = JinnReference.extend({
-                    name: name,
-                });
-                break;
-            case 'empty':
-                NodeOrMark = JinnEmptyElement.extend({
-                    name: name,
-                });
-                break;
-            case 'list':
-                NodeOrMark = JinnList.extend({
-                    name: name,
-                    content: def.content || 'item+',
-                });
-                break;
-            case 'listItem':
-                NodeOrMark = JinnItem.extend({
-                    name: name,
-                    content: def.content || 'p block*',
-                    addOptions() {
-                        return {
-                            ...this.parent?.(),
-                            tagName: def.tagName, // Allow custom tag name override
-                        };
+    Object.entries(schemaDef.schema).forEach(([baseName, rawDef]) => {
+        // Support an array of conditional definitions for a single XML element name.
+        // Each item may have a "when" object (attr→value map) to conditionally match.
+        const defs = Array.isArray(rawDef) ? rawDef : [rawDef];
+        const conditions = defs.map(d => d.when || null);
+
+        defs.forEach((def, index) => {
+            // First item keeps the base name so existing anchorName/noteName references work.
+            // Subsequent items get baseName + index (e.g. "xref1").
+            const name = index === 0 ? baseName : `${baseName}${index}`;
+
+            // Build getAttrs for parseHTML when conditional dispatch is needed.
+            let getAttrs = null;
+            if (def.when) {
+                const cond = def.when;
+                getAttrs = (el) => {
+                    const matches = Object.entries(cond).every(([attr, val]) => el.getAttribute(attr) === val);
+                    return matches ? null : false;
+                };
+            } else if (conditions.some(c => c !== null)) {
+                // Default (no "when"): exclude elements matched by sibling conditions.
+                const siblings = conditions.filter(c => c !== null);
+                getAttrs = (el) => {
+                    const excluded = siblings.some(cond =>
+                        Object.entries(cond).every(([attr, val]) => el.getAttribute(attr) === val)
+                    );
+                    return excluded ? false : null;
+                };
+            }
+
+            let NodeOrMark;
+            switch (def.type) {
+                case 'inline':
+                    NodeOrMark = JinnInline.extend({
+                        name: name,
+                    });
+                    break;
+                case 'anchor':
+                    NodeOrMark = JinnAnchor.extend({
+                        name: name,
+                    });
+                    break;
+                case 'ref':
+                    NodeOrMark = JinnReference.extend({
+                        name: name,
+                    });
+                    break;
+                case 'empty':
+                    NodeOrMark = JinnEmptyElement.extend({
+                        name: name,
+                    });
+                    break;
+                case 'list':
+                    NodeOrMark = JinnList.extend({
+                        name: name,
+                        content: def.content || 'item+',
+                    });
+                    break;
+                case 'listItem':
+                    NodeOrMark = JinnItem.extend({
+                        name: name,
+                        content: def.content || 'p block*',
+                        addOptions() {
+                            return {
+                                ...this.parent?.(),
+                                tagName: def.tagName,
+                            };
+                        },
+                        renderHTML({ HTMLAttributes }) {
+                            const prefix = this.options.prefix || 'tei-';
+                            if (this.options.tagName) {
+                                return [`${prefix}${this.options.tagName}`, HTMLAttributes, 0];
+                            }
+                            const tag = `${prefix}${this.name}`;
+                            return [tag, HTMLAttributes, 0];
+                        },
+                        parseHTML() {
+                            const prefix = this.options.prefix || 'tei-';
+                            const customTag = this.options.tagName;
+                            const defaultTag = `${prefix}${this.name}`;
+                            const tags = [];
+                            if (customTag) {
+                                tags.push({ tag: customTag });
+                            }
+                            tags.push({ tag: defaultTag });
+                            return tags;
+                        },
+                    });
+                    break;
+                case 'block':
+                    NodeOrMark = JinnBlock.extend({
+                        name: name,
+                        group: def.group || 'block',
+                        defining: def.defining,
+                        isolating: def.isolating,
+                        priority: def.priority,
+                        inline: def.inline,
+                        content: def.content,
+                        selectable: def.selectable,
+                    });
+                    break;
+                case 'graphic':
+                    NodeOrMark = JinnGraphic.extend({
+                        name: name,
+                    });
+                    break;
+                case 'table':
+                    NodeOrMark = JinnTable.extend({});
+                    break;
+                case 'row':
+                    NodeOrMark = JinnRow.extend({});
+                    break;
+                case 'cell':
+                    NodeOrMark = JinnCell.extend({});
+                    break;
+            }
+
+            // When getAttrs is needed or the node name differs from the XML element name,
+            // override parseHTML/renderHTML so both use the base element name (baseName).
+            if (getAttrs || name !== baseName) {
+                const capturedBaseName = baseName;
+                const capturedGetAttrs = getAttrs;
+                NodeOrMark = NodeOrMark.extend({
+                    parseHTML() {
+                        const p = this.options.prefix || 'tei-';
+                        const rule = { tag: `${p}${capturedBaseName}` };
+                        if (capturedGetAttrs) rule.getAttrs = capturedGetAttrs;
+                        return [rule];
                     },
                     renderHTML({ HTMLAttributes }) {
-                        const prefix = this.options.prefix || 'tei-';
-                        // Use custom tagName if provided, but add prefix for HTML custom elements
-                        // (prefix is only omitted in XML output, not in editor HTML)
-                        if (this.options.tagName) {
-                            return [`${prefix}${this.options.tagName}`, HTMLAttributes, 0];
-                        }
-                        const tag = `${prefix}${this.name}`;
-                        return [tag, HTMLAttributes, 0];
-                    },
-                    parseHTML() {
-                        const prefix = this.options.prefix || 'tei-';
-                        const customTag = this.options.tagName;
-                        const defaultTag = `${prefix}${this.name}`;
-                        
-                        const tags = [];
-                        if (customTag) {
-                            tags.push({ tag: customTag });
-                        }
-                        tags.push({ tag: defaultTag });
-                        return tags;
+                        const p = this.options.prefix || 'tei-';
+                        return [`${p}${capturedBaseName}`, HTMLAttributes, 0];
                     },
                 });
-                break;
-            case 'block':
-                NodeOrMark = JinnBlock.extend({
-                    name: name,
-                    group: def.group || 'block',
-                    defining: def.defining,
-                    isolating: def.isolating,
-                    priority: def.priority,
-                    inline: def.inline,
-                    content: def.content,
-                    selectable: def.selectable,
-                });
-                break;
-            case 'graphic':
-                NodeOrMark = JinnGraphic.extend({
-                    name: name,
-                });
-                break;
-            case 'table':
-                NodeOrMark = JinnTable.extend({});
-                break;
-            case 'row':
-                NodeOrMark = JinnRow.extend({});
-                break;
-            case 'cell':
-                NodeOrMark = JinnCell.extend({});
-                break;
-        }
-        // Merge global attributes with node-specific attributes
-        const attributes = { ...schemaDef.attributes, ...def.attributes };
-        const config = {
-            prefix: prefix, // Pass the format prefix to extensions
-            shortcuts: def.keyboard,
-            attributes: attributes,
-            label: def.label,
-        };
-        if (def.inputRules) {
-            config.inputRules = def.inputRules;
-        }
-        // Pass footnote options to anchor extension
-        if (def.type === 'anchor' && footnoteOptions) {
-            if (footnoteOptions.noteName) {
-                config.noteName = footnoteOptions.noteName;
             }
-            if (footnoteOptions.anchorName) {
-                config.anchorName = footnoteOptions.anchorName;
+
+            // Merge global attributes with node-specific attributes
+            const attributes = { ...schemaDef.attributes, ...def.attributes };
+            const config = {
+                prefix: prefix,
+                shortcuts: def.keyboard,
+                attributes: attributes,
+                label: def.label,
+            };
+            if (def.inputRules) {
+                config.inputRules = def.inputRules;
             }
-            if (footnoteOptions.linkDirection) {
-                config.linkDirection = footnoteOptions.linkDirection;
+            // Pass footnote options to anchor extension
+            if (def.type === 'anchor' && footnoteOptions) {
+                if (footnoteOptions.noteName) {
+                    config.noteName = footnoteOptions.noteName;
+                }
+                if (footnoteOptions.anchorName) {
+                    config.anchorName = footnoteOptions.anchorName;
+                }
+                if (footnoteOptions.linkDirection) {
+                    config.linkDirection = footnoteOptions.linkDirection;
+                }
             }
-        }
-        extensions.push(NodeOrMark.configure(config));
+            extensions.push(NodeOrMark.configure(config));
+        });
     });
     return extensions;
 }

--- a/src/jats-schema.json
+++ b/src/jats-schema.json
@@ -127,38 +127,52 @@
                 }
             }
         },
-        "xref": {
-            "type": "anchor",
-            "attributes": {
-                "rid": {
-                    "type": "string"
-                },
-                "ref-type": {
-                    "type": "string",
-                    "default": "fn"
-                },
-                "type": {
-                    "type": "string",
-                    "default": "note"
-                }
-            },
-            "keyboard": {
-                "Alt-Shift-r": {
-                    "attributes": {}
-                }
-            },
-            "toolbar": {
-                "Footnote": {
-                    "attributes": {
-                        "type": "note",
-                        "ref-type": "fn",
-                        "_reference": "*"
+        "xref": [
+            {
+                "when": { "ref-type": "fn" },
+                "type": "anchor",
+                "attributes": {
+                    "rid": {
+                        "type": "string"
                     },
-                    "label": "<i class='bi bi-123'></i>",
-                    "order": 2
+                    "ref-type": {
+                        "type": "string",
+                        "default": "fn"
+                    },
+                    "type": {
+                        "type": "string",
+                        "default": "note"
+                    }
+                },
+                "keyboard": {
+                    "Alt-Shift-r": {
+                        "attributes": {}
+                    }
+                },
+                "toolbar": {
+                    "Footnote": {
+                        "attributes": {
+                            "type": "note",
+                            "ref-type": "fn",
+                            "_reference": "*"
+                        },
+                        "label": "<i class='bi bi-123'></i>",
+                        "order": 2
+                    }
+                }
+            },
+            {
+                "type": "inline",
+                "attributes": {
+                    "rid": {
+                        "type": "string"
+                    },
+                    "ref-type": {
+                        "type": "string"
+                    }
                 }
             }
-        },
+        ],
         "title": {
             "type": "block",
             "group": "heading",

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -59,8 +59,12 @@ export class Toolbar {
         }
 
         // Add node-specific toolbar items
-        Object.entries(schemaDef.schema).forEach(([name, def]) => {
+        Object.entries(schemaDef.schema).forEach(([baseName, rawDef]) => {
+            const defs = Array.isArray(rawDef) ? rawDef : [rawDef];
+            defs.forEach((def, index) => {
             if (!def.toolbar) return;
+            // Array items: first keeps base name, subsequent get baseName+index (mirrors createFromSchema)
+            const name = index === 0 ? baseName : `${baseName}${index}`;
             Object.entries(def.toolbar).forEach(([label, toolbarDef]) => {
                 if (toolbarDef.select) {
                     if (!selectItems.has(toolbarDef.select)) {
@@ -87,6 +91,7 @@ export class Toolbar {
                     });
                 }
             });
+            }); // end defs.forEach
         });
 
         // Sort all items by order
@@ -282,7 +287,16 @@ export class Toolbar {
         const buttons = this.toolbar.querySelectorAll('a[data-name]');
         buttons.forEach((button) => {
             const buttonName = button.dataset.name;
-            const nodeType = this.schemaDef.schema[buttonName];
+            let nodeType = this.schemaDef.schema[buttonName];
+            if (Array.isArray(nodeType)) {
+                nodeType = nodeType[0];
+            } else if (!nodeType) {
+                const m = buttonName.match(/^(.+?)(\d+)$/);
+                if (m) {
+                    const base = this.schemaDef.schema[m[1]];
+                    if (Array.isArray(base)) nodeType = base[parseInt(m[2])];
+                }
+            }
 
             if (!nodeType) return;
 

--- a/src/util/colors.js
+++ b/src/util/colors.js
@@ -64,14 +64,16 @@ export function colorCssFromSchema(schema) {
         colorVariables[`--tei-div-color-${i}`] = color;
     }
     let inlineCount = 5;
-    Object.entries(schema.schema).forEach(([name, def]) => {
+    Object.entries(schema.schema).forEach(([name, rawDef]) => {
         const hue = (baseH + inlineCount * 60) % 360;
         const color = hslToHex(hue, baseS, baseL);
         colorVariables[`--tei-${name}-color`] = `${color}`;
 
-        if (def.type === 'inline' || def.type === 'empty') {
+        // rawDef may be an array of conditional definitions; check if any item is inline/empty
+        const defs = Array.isArray(rawDef) ? rawDef : [rawDef];
+        if (defs.some(def => def.type === 'inline' || def.type === 'empty')) {
             cssStyles.push(`
-                .debug tei-${name}::after { 
+                .debug tei-${name}::after {
                     background-color: var(--tei-${name}-color);
                     content: "${name}";
                 }

--- a/src/util/module-jats.xq
+++ b/src/util/module-jats.xq
@@ -133,21 +133,23 @@ declare function jt:export ($nodes as node()*, $input as document-node(), $meta 
                         jt:export($node/node(), $input, $meta)
                 }
             case element(jats-xref) return
-                (: Convert jats-xref back to xref with ref-type="fn" :)
-                element xref {
-                    $node/@* except ($node/@id, $node/@ref-type),
-                    attribute ref-type { 
-                        if ($node/@ref-type) then $node/@ref-type else 'fn' 
-                    },
-                    (: rid should already be set from the node attributes :)
-                    if ($node/@rid) then
-                        attribute rid { $node/@rid }
-                    else if ($node/@id) then
-                        (: If no rid but has id, this shouldn't happen in proper JATS :)
-                        ()
-                    else (),
-                    jt:export($node/node(), $input, $meta)
-                }
+                if ($node/node()) then
+                    (: Non-fn inline xref (e.g. ref-type="bibr", "aff", "fig") — preserve all attributes and content :)
+                    element xref {
+                        $node/@*,
+                        jt:export($node/node(), $input, $meta)
+                    }
+                else
+                    (: fn anchor — drop editor-internal @id, keep rid and ref-type :)
+                    element xref {
+                        $node/@* except ($node/@id, $node/@ref-type),
+                        attribute ref-type {
+                            if ($node/@ref-type) then $node/@ref-type else 'fn'
+                        },
+                        if ($node/@rid) then
+                            attribute rid { $node/@rid }
+                        else ()
+                    }
             case element(jats-fnGroup) return
                 (: Convert jats-fnGroup back to fn-group :)
                 element fn-group {

--- a/src/util/serialize.js
+++ b/src/util/serialize.js
@@ -21,6 +21,29 @@ function compareMarks(mark1, mark2) {
     return mark1.type === mark2.type && JSON.stringify(mark1.attrs) === JSON.stringify(mark2.attrs);
 }
 
+// Resolve the XML element name for a ProseMirror type.
+// Array schema entries generate numbered variants (e.g. "xref1") that still map to the base XML tag.
+function resolveXmlTagName(schemaDef, typeName) {
+    if (schemaDef.schema[typeName] !== undefined) return typeName;
+    const match = typeName.match(/^(.+?)\d+$/);
+    if (match && schemaDef.schema[match[1]] !== undefined) return match[1];
+    return typeName;
+}
+
+// Resolve the schema definition object for a ProseMirror type name, handling array entries.
+function resolveSchemaEntry(schemaDef, typeName) {
+    const entry = schemaDef.schema[typeName];
+    if (entry !== undefined) {
+        return Array.isArray(entry) ? entry[0] : entry;
+    }
+    const match = typeName.match(/^(.+?)(\d+)$/);
+    if (match) {
+        const base = schemaDef.schema[match[1]];
+        if (Array.isArray(base)) return base[parseInt(match[2])];
+    }
+    return undefined;
+}
+
 class Serializer {
     constructor(editor, schemaDef) {
         this.editor = editor;
@@ -47,7 +70,7 @@ class Serializer {
                             if (!compareMarks(lastOpen, prevMark)) {
                                 console.error('Serialization mismatch');
                             }
-                            text += `</${prevMark.type}>`;
+                            text += `</${resolveXmlTagName(this.schemaDef, prevMark.type)}>`;
                         }
                     });
                 }
@@ -65,14 +88,14 @@ class Serializer {
                 });
                 openingMarks.forEach((mark) => {
                     this.openMarks.push(mark);
-                    const nodeDef = this.schemaDef.schema[mark.type];
-                    const tagName = mark.type;
+                    const nodeDef = resolveSchemaEntry(this.schemaDef, mark.type);
+                    const tagName = resolveXmlTagName(this.schemaDef, mark.type);
                     const attrs = mark.attrs
                         ? Object.entries(mark.attrs)
                               .filter(([_, value]) => value !== null)
                               .map(([key, value]) => `${key}="${value}"`)
                         : [];
-                    if (nodeDef.preserveSpace) {
+                    if (nodeDef?.preserveSpace) {
                         attrs.push('xml:space="preserve"');
                     }
                     text += `<${tagName}${attrs.length > 0 ? ' ' + attrs.join(' ') : ''}>`;
@@ -80,13 +103,13 @@ class Serializer {
                 text += cleanNodeText;
                 if (!next) {
                     this.openMarks.reverse().forEach((mark) => {
-                        text += `</${mark.type}>`;
+                        text += `</${resolveXmlTagName(this.schemaDef, mark.type)}>`;
                     });
                     this.openMarks = [];
                 }
             } else {
                 this.openMarks.reverse().forEach((prevMark) => {
-                    text += `</${prevMark.type}>`;
+                    text += `</${resolveXmlTagName(this.schemaDef, prevMark.type)}>`;
                 });
                 this.openMarks = [];
                 text += cleanNodeText;
@@ -94,9 +117,9 @@ class Serializer {
             return text;
         }
 
-        // Get tag name from schema definition (tagName) or fall back to node.type
-        const nodeDef = this.schemaDef.schema[node.type];
-        let tagName = nodeDef?.tagName || node.type;
+        // Get tag name from schema definition (tagName) or fall back to the XML element name
+        const nodeDef = resolveSchemaEntry(this.schemaDef, node.type);
+        let tagName = nodeDef?.tagName || resolveXmlTagName(this.schemaDef, node.type);
         // If tagName is defined (custom tag), use it as-is (no prefix in XML output)
         // The prefix is only for HTML custom elements in the editor, not for XML output
         const attrs = node.attrs
@@ -135,7 +158,7 @@ class Serializer {
             if (next?.isText && next.marks.some((mark) => compareMarks(mark, openMark))) {
                 return '';
             }
-            const tagName = openMark.type;
+            const tagName = resolveXmlTagName(this.schemaDef, openMark.type);
             this.openMarks = this.openMarks.filter((mark) => !compareMarks(mark, openMark));
             text += `</${tagName}>`;
         });


### PR DESCRIPTION
* map elements with same name to different prosemirror nodes depending on attribute information
* introduces a `when` condition listing attribute names and values to match

Example use case: element `xref` in JATS can be a footnote anchor, but also a reference. Both need to be handled differently.